### PR TITLE
Add ReadBucketReplications and WriteBucketReplications capabilities

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -217,6 +217,8 @@ pub enum Capability {
     ReadFileRetentions,
     WriteFileRetentions,
     BypassGovernance,
+    ReadBucketReplications,
+    WriteBucketReplications,
 }
 
 /// Log onto the B2 API.
@@ -429,7 +431,9 @@ impl CreateKeyBuilder {
                     | Capability::WriteFileLegalHolds
                     | Capability::ReadFileRetentions
                     | Capability::WriteFileRetentions
-                    | Capability::BypassGovernance => {},
+                    | Capability::BypassGovernance
+                    | Capability::ReadBucketReplications
+                    | Capability::WriteBucketReplications => {},
                     cap => return Err(ValidationError::Incompatible(format!(
                         "Invalid capability when bucket_id is set: {:?}",
                         cap

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -984,6 +984,7 @@ pub struct Bucket {
 
 impl Bucket {
     pub fn account_id(&self) -> &str { &self.account_id }
+    pub fn bucket_id(&self) -> &str { &self.bucket_id }
     pub fn name(&self) -> &str { &self.bucket_name }
     pub fn bucket_type(&self) -> BucketType { self.bucket_type }
     pub fn info(&self) -> &serde_json::Value { &self.bucket_info }


### PR DESCRIPTION
This PR adds the capabilities ReadBucketReplications and
WriteBucketReplications to allow authorize_account to function again