### PR TITLE
Fix deserialization error on missing file retention

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -271,7 +271,7 @@ impl FileRetentionSetting {
 pub struct FileRetention {
     #[serde(rename = "isClientAuthorizedToRead")]
     can_read: bool,
-    value: FileRetentionSetting,
+    value: Option<FileRetentionSetting>,
 }
 
 impl FileRetention {
@@ -280,7 +280,7 @@ impl FileRetention {
     /// If not authorized to read the settings, returns `None`.
     pub fn settings(&self) -> Option<FileRetentionSetting> {
         if self.can_read {
-            Some(self.value)
+            self.value
         } else {
             None
         }


### PR DESCRIPTION
Fix https://todo.sr.ht/~rjframe/b2-client/8

The field `FileRetention::value` might be null in some cases. Please refer to my test program in the linked issue to reproduce the bug.

## Sample response from b2

```json
{
  "files": [
    {
      "accountId": "redacted",
      "action": "upload",
      "bucketId": "redacted",
      "contentLength": 286219833,
      "contentMd5": null,
      "contentSha1": "none",
      "contentType": "aplication/octet-stream",
      "fileId": "redacted",
      "fileInfo": {
        "src_last_modified_millis": "1668455229615",
        "large_file_sha1": "90750400ac8f18c97ae284b52fa1d9651e752790"
      },
      "fileName": "redacted",
      "fileRetention": {
        "isClientAuthorizedToRead": false,
        "value": null
      },
      "legalHold": {
        "isClientAuthorizedToRead": false,
        "value": null
      },
      "serverSideEncryption": {
        "algorithm": null,
        "mode": null
      },
      "uploadTimestamp": 1668455297058
    }
  ],
  "nextFileName": null
}
```